### PR TITLE
Re-Enable z uart, with unused diag pin

### DIFF
--- a/src/modules/klipper/filesystem/home/pi/printer_data/config/printer.cfg
+++ b/src/modules/klipper/filesystem/home/pi/printer_data/config/printer.cfg
@@ -73,11 +73,11 @@ position_min: 0
 position_max: 350
 
 # TMC UART unavailable in version 3.5.1 of the Prometheus board
-#[tmc2209 stepper_z]
-#uart_pin: gpio10
-##diag_pin: gpio23
-#run_current: 1.1
-#stealthchop_threshold: 999999
+[tmc2209 stepper_z]
+uart_pin: gpio10
+diag_pin: gpio27
+run_current: 1.1
+stealthchop_threshold: 999999
 
 [output_pin led_array]
 pin: gpio29


### PR DESCRIPTION
We've tested this on two boards now (Sam's and mine)