### PR TITLE
Base Image: Refactor build processes to rely on an initial base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,18 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
+  build_base:
+    uses: ./.github/workflows/build_base.yml
   build_nanodlp:
+    needs: build_base
     uses: ./.github/workflows/build_variant.yml
     with:
       variant: nanodlp-based
+      image_name: ${{ needs.build_base.outputs.image_name }}
   build_odyssey:
+    needs: build_base
     uses: ./.github/workflows/build_variant.yml
     with:
       variant: odyssey-based
+      image_name: ${{ needs.build_base.outputs.image_name }}
 

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -57,11 +57,11 @@ jobs:
           NOW=$(date +"%Y-%m-%d-%H%M")
           IMAGE=$NOW-prometheusos-BASE-$DIST_VERSION
           cp repository/src/workspace/*.img $IMAGE.img
-          tar -czvf $IMAGE.tar.gz  $IMAGE.img
+          tar -cJf $IMAGE.xz  $IMAGE.img
           echo "image=$IMAGE" >> $GITHUB_OUTPUT
           echo "dist_version=$DIST_VERSION" >> $GITHUB_OUTPUT
   
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.image }}
-          path: ${{ steps.artifact.outputs.image }}.img
+          path: ${{ steps.artifact.outputs.image }}.xz

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -57,11 +57,11 @@ jobs:
           NOW=$(date +"%Y-%m-%d-%H%M")
           IMAGE=$NOW-prometheusos-BASE-$DIST_VERSION
           cp repository/src/workspace/*.img $IMAGE.img
-          tar -cJf $IMAGE.xz  $IMAGE.img
+          tar -cJf $IMAGE.img.xz  $IMAGE.img
           echo "image=$IMAGE" >> $GITHUB_OUTPUT
           echo "dist_version=$DIST_VERSION" >> $GITHUB_OUTPUT
   
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.image }}
-          path: ${{ steps.artifact.outputs.image }}.xz
+          path: ${{ steps.artifact.outputs.image }}.img.xz

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -1,0 +1,67 @@
+on:
+    workflow_call:
+      outputs:
+        image_name:
+          description: "The filename of the uploaded base image"
+          value: ${{ jobs.build.outputs.image_name }}
+
+jobs:
+    build:
+      runs-on: ubuntu-latest
+      outputs:
+        image_name: ${{ steps.artifact.outputs.image }}
+      steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Install Dependencies
+        run: |
+          sudo apt update
+          sudo apt install coreutils p7zip-full qemu-user-static
+      - name: Checkout CustomPiOS
+        uses: actions/checkout@v4
+        with:
+          repository: 'guysoft/CustomPiOS'
+          path: CustomPiOS
+          ref: '70f1ae537a02195f1ba4f0a51ed381628e575c66'
+  
+      - name: Checkout Project Repository
+        uses: actions/checkout@v4
+        with:
+          path: repository
+          submodules: true
+  
+      - name: Download Raspbian Image
+        run: |
+          cd repository/src/image
+          wget -c --trust-server-names 'https://downloads.raspberrypi.org/raspios_lite_armhf_latest'
+      - name: Update CustomPiOS Paths
+        run: |
+          cd repository/src
+          ../../CustomPiOS/src/update-custompios-paths
+  
+      - name: Build Image
+        id: build
+        run: |
+          sudo modprobe loop
+          cd repository/src
+          sudo bash -x ./build_dist
+  
+      - name: Prepare artifact
+        id: artifact
+        run: |
+          source repository/src/config
+          NOW=$(date +"%Y-%m-%d-%H%M")
+          IMAGE=$NOW-prometheusos-BASE-$DIST_VERSION
+          cp repository/src/workspace/*.img $IMAGE.img
+          tar -czvf $IMAGE.tar.gz  $IMAGE.img
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "dist_version=$DIST_VERSION" >> $GITHUB_OUTPUT
+  
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact.outputs.image }}
+          path: ${{ steps.artifact.outputs.image }}.img

--- a/.github/workflows/build_variant.yml
+++ b/.github/workflows/build_variant.yml
@@ -9,6 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Remove unnecessary files
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Install Dependencies
       run: |
         sudo apt update

--- a/.github/workflows/build_variant.yml
+++ b/.github/workflows/build_variant.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Download base image
       uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.image_name }}
+        name: ${{ inputs.image_name }}.xz
         path: repository/src/image
 
     - name: Update CustomPiOS Paths
@@ -60,7 +60,7 @@ jobs:
         NOW=$(date +"%Y-%m-%d-%H%M")
         IMAGE=$NOW-prometheusos-${{ inputs.variant }}-$DIST_VERSION
         cp repository/src/workspace-${{ inputs.variant }}/*.img $IMAGE.img
-        tar -czvf $IMAGE.tar.gz  $IMAGE.img
+        tar -cJf $IMAGE.xz  $IMAGE.img
         echo "image=$IMAGE" >> $GITHUB_OUTPUT
         echo "dist_version=$DIST_VERSION" >> $GITHUB_OUTPUT
 
@@ -73,7 +73,7 @@ jobs:
       uses: ncipollo/release-action@v1
       if: github.ref == 'refs/heads/main'
       with:
-        artifacts: ${{ steps.compress.outputs.image }}.tar.gz
+        artifacts: ${{ steps.compress.outputs.image }}.xz
         tag: v${{ steps.compress.outputs.dist_version }}
         skipIfReleaseExists: true
         omitBodyDuringUpdate: true

--- a/.github/workflows/build_variant.yml
+++ b/.github/workflows/build_variant.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Download base image
       uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.image_name }}.xz
+        name: ${{ inputs.image_name }}
         path: repository/src/image
 
     - name: Update CustomPiOS Paths

--- a/.github/workflows/build_variant.yml
+++ b/.github/workflows/build_variant.yml
@@ -4,6 +4,9 @@ on:
       variant:
         required: true
         type: string
+      image_name:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -27,15 +30,17 @@ jobs:
         ref: '70f1ae537a02195f1ba4f0a51ed381628e575c66'
 
     - name: Checkout Project Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: repository
         submodules: true
 
-    - name: Download Raspbian Image
-      run: |
-        cd repository/src/image
-        wget -c --trust-server-names 'https://downloads.raspberrypi.org/raspios_lite_armhf_latest'
+    - name: Download base image
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.image_name }}
+        path: repository/src/image
+
     - name: Update CustomPiOS Paths
       run: |
         cd repository/src

--- a/.github/workflows/build_variant.yml
+++ b/.github/workflows/build_variant.yml
@@ -60,7 +60,7 @@ jobs:
         NOW=$(date +"%Y-%m-%d-%H%M")
         IMAGE=$NOW-prometheusos-${{ inputs.variant }}-$DIST_VERSION
         cp repository/src/workspace-${{ inputs.variant }}/*.img $IMAGE.img
-        tar -cJf $IMAGE.xz  $IMAGE.img
+        tar -cJf $IMAGE.img.xz  $IMAGE.img
         echo "image=$IMAGE" >> $GITHUB_OUTPUT
         echo "dist_version=$DIST_VERSION" >> $GITHUB_OUTPUT
 
@@ -73,7 +73,7 @@ jobs:
       uses: ncipollo/release-action@v1
       if: github.ref == 'refs/heads/main'
       with:
-        artifacts: ${{ steps.compress.outputs.image }}.xz
+        artifacts: ${{ steps.compress.outputs.image }}.img.xz
         tag: v${{ steps.compress.outputs.dist_version }}
         skipIfReleaseExists: true
         omitBodyDuringUpdate: true

--- a/src/config
+++ b/src/config
@@ -16,7 +16,7 @@ export BASE_RELEASE_IMAGE_NAME="PrometheusOS"
 # Prometheus Settings
 export KLIPPER_REPO_SHIP="https://github.com/TheContrappostoShop/klipper.git"
 
-export MODULES="base(pkgupgrade,network,klipper,nanodlp,odyssey,prometheus_config,openocd)"
+export MODULES="base(pkgupgrade,network,auto-mount-removable,klipper,prometheus_config,openocd,user_rename)"
 
 # Prevent known wifi issues
 export NETWORK_DISABLE_PWRSAVE=no

--- a/src/modules/prometheus_config/start_chroot_script
+++ b/src/modules/prometheus_config/start_chroot_script
@@ -23,13 +23,15 @@ for dir in ${PROMETHEUS_CONFIG_DIRS}; do
     sudo -u "${BASE_USER}" mkdir -p "${dir}"
 done
 
-sudo -u "${BASE_USER}" cp prometheus_config/klipper/.config klipper/
-sudo -u "${BASE_USER}" cp prometheus_config/klipper/config/* printer_data/config/
+sudo -u "${BASE_USER}" mv prometheus_config/klipper/.config klipper/
+sudo -u "${BASE_USER}" mv prometheus_config/klipper/config/* printer_data/config/
 
 # Only copy nanodlp files if neccessary
 if [[ $MODULES == *"nanodlp"* ]]; then
-    sudo -u "${BASE_USER}" cp prometheus_config/nanodlp/* nanodlp/db/
+    sudo -u "${BASE_USER}" mv prometheus_config/nanodlp/* nanodlp/db/
 fi
+
+sudo -u "${BASE_USER}" rm -rf prometheus_config
 
 # if Odyssey is included in this build, then include the relevant klipper config
 # at the head of printer.cfg

--- a/src/variants/nanodlp-based/config
+++ b/src/variants/nanodlp-based/config
@@ -1,2 +1,2 @@
 export MODULES="base(nanodlp)"
-export BASE_ZIP_IMG="image/*.xz"
+export BASE_ZIP_IMG=$(ls -t image/*.xz | head -n 1)

--- a/src/variants/nanodlp-based/config
+++ b/src/variants/nanodlp-based/config
@@ -1,1 +1,1 @@
-export MODULES="base(pkgupgrade,network,klipper,nanodlp,prometheus_config,openocd,user_rename)"
+export MODULES="base(nanodlp)"

--- a/src/variants/nanodlp-based/config
+++ b/src/variants/nanodlp-based/config
@@ -1,1 +1,2 @@
 export MODULES="base(nanodlp)"
+export BASE_ZIP_IMG="image/*.xz"

--- a/src/variants/nanodlp-based/config
+++ b/src/variants/nanodlp-based/config
@@ -1,2 +1,2 @@
 export MODULES="base(nanodlp)"
-export BASE_ZIP_IMG=$(ls -t image/*.xz | head -n 1)
+export BASE_ZIP_IMG=$(ls -t ${DIST_PATH}/image/*.xz | head -n 1)

--- a/src/variants/odyssey-based/config
+++ b/src/variants/odyssey-based/config
@@ -1,1 +1,1 @@
-export MODULES="base(pkgupgrade,network,auto-mount-removable,klipper,moonraker,mainsail,odyssey,prometheus_config,openocd,user_rename)"
+export MODULES="base(moonraker,mainsail,odyssey)"

--- a/src/variants/odyssey-based/config
+++ b/src/variants/odyssey-based/config
@@ -1,1 +1,2 @@
 export MODULES="base(moonraker,mainsail,odyssey)"
+export BASE_ZIP_IMG="image/*.xz"

--- a/src/variants/odyssey-based/config
+++ b/src/variants/odyssey-based/config
@@ -1,2 +1,2 @@
 export MODULES="base(moonraker,mainsail,odyssey)"
-export BASE_ZIP_IMG="image/*.xz"
+export BASE_ZIP_IMG=$(ls -t image/*.xz | head -n 1)

--- a/src/variants/odyssey-based/config
+++ b/src/variants/odyssey-based/config
@@ -1,2 +1,2 @@
 export MODULES="base(moonraker,mainsail,odyssey)"
-export BASE_ZIP_IMG=$(ls -t image/*.xz | head -n 1)
+export BASE_ZIP_IMG=$(ls -t ${DIST_PATH}/image/*.xz | head -n 1)


### PR DESCRIPTION
Will re-base after the parent branch is merged to main


Update base image config
Modify variant configs to only install modules which differ from base image
Modify github workflows to run the base image creation first, then re-use that artifact for the following variant image workflows